### PR TITLE
compile_mac.f90の不要な出力を削除

### DIFF
--- a/src/compile_mac.f90
+++ b/src/compile_mac.f90
@@ -20,7 +20,6 @@ program fem
     call get_command_argument(1, solver_name, status=status)
 
     open(10,file="./solvers/"//trim(solver_name)//"/sources.dat",status='old', iostat=iostat)
-print *,"../solvers/"//trim(solver_name)//"/sources.dat"
     if (iostat /= 0) call error("Cannot read solvers/"//solver_name//"/sources.dat")
     read (10,*,iostat=iostat) file_num
     if (iostat /= 0) call error("sources.dat is badly formated")


### PR DESCRIPTION
compile_mac.f90の不要な出力を削除
